### PR TITLE
Use murmur3 for hashing

### DIFF
--- a/optimizely/Cargo.toml
+++ b/optimizely/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 serde_json = "1.0"
 thiserror = "1.0"
 error-stack = "0.5"
-fasthash = "0.4"
+murmur3 = "0.5.2"
 log = "0.4"
 
 [dependencies.serde]

--- a/optimizely/src/client/user.rs
+++ b/optimizely/src/client/user.rs
@@ -1,5 +1,5 @@
 // External imports
-use fasthash::murmur3::hash32_with_seed as murmur3_hash;
+use murmur3::murmur3_32 as murmur3_hash;
 use std::collections::HashMap;
 
 // Imports from crate
@@ -223,7 +223,8 @@ impl UserContext<'_> {
 
         // To hash the bucket key it needs to be converted to an array of `u8` bytes
         // Use Murmur3 (32-bit) with seed
-        let hash_value = murmur3_hash(bucketing_key.as_bytes(), HASH_SEED);
+        let mut bytes = bucketing_key.as_bytes();
+        let hash_value = murmur3_hash(&mut bytes, HASH_SEED).unwrap();
 
         // Bring the hash into a range of 0 to 10_000
         let bucket_value = ((hash_value as f64) / (u32::MAX as f64) * MAX_OF_RANGE) as u64;


### PR DESCRIPTION
This PR updates the hash library from "fasthash" to "murmur3" due to compilation issues on a Mac. Looking through the fasthash repository there are many compilation issues across various devices.

This was raised in https://github.com/MarkBiesheuvel/optimizely-rust-sdk/issues/17 and a PR was suggested.