### PR TITLE
Use another approach for take_if instead of an unstable feature

### DIFF
--- a/optimizely/src/event_api/batched_event_dispatcher.rs
+++ b/optimizely/src/event_api/batched_event_dispatcher.rs
@@ -60,7 +60,11 @@ impl Default for BatchedEventDispatcher {
                 }
 
                 // Send payload if reached the batch threshold
-                if let Some(payload) = payload_option.take_if(|payload| payload.size() >= DEFAULT_BATCH_THRESHOLD) {
+                if payload_option
+                    .as_ref()
+                    .map_or(false, |payload| payload.size() >= DEFAULT_BATCH_THRESHOLD)
+                {
+                    let payload = payload_option.take().unwrap();
                     log::debug!("Reached DEFAULT_BATCH_THRESHOLD");
                     payload.send();
                 }


### PR DESCRIPTION
When running this I got an error about "take_if" being an unstable feature. I assume the nightly or development build is fine with this, but it doesn't compile without changing this.
```
cargo run
   Compiling optimizely v0.3.0 (/optimizely-rust-sdk/optimizely)
error[E0658]: use of unstable library feature 'option_take_if'
  --> /optimizely-rust-sdk/optimizely/src/event_api/batched_event_dispatcher.rs:63:55
   |
63 |                 if let Some(payload) = payload_option.take_if(|payload| payload.size() >= DEFAULT_BATCH_THRESHOLD) {
   |                                                       ^^^^^^^
   |
   = note: see issue #98934 <https://github.com/rust-lang/rust/issues/98934> for more information

For more information about this error, try `rustc --explain E0658`.
error: could not compile `optimizely` (lib) due to 1 previous error
```

This PR updates the logic for this. If it is meant to use "take_if" and I need to update or enable something then happy for this to be closed.