### PR TITLE
Implement Send and Sync for thread safety

### DIFF
--- a/optimizely/src/event_api/trait_event_dispatcher.rs
+++ b/optimizely/src/event_api/trait_event_dispatcher.rs
@@ -5,7 +5,7 @@ use crate::{client::UserContext, Conversion, Decision};
 ///
 /// It is possible to make a custom event dispatcher by implementing this trait
 /// TODO: add example again
-pub trait EventDispatcher {
+pub trait EventDispatcher: Send + Sync {
     /// Send conversion event to destination
     fn send_conversion_event(&self, user_context: &UserContext, conversion: Conversion);
 

--- a/optimizely/tests/common/mod.rs
+++ b/optimizely/tests/common/mod.rs
@@ -34,6 +34,10 @@ pub(super) struct EventStore {
     decisions: DecisionList,
 }
 
+// Implement Send and Sync for EventStore
+unsafe impl Send for EventStore {}
+unsafe impl Sync for EventStore {}
+
 // Return a new reference counted point to the list
 impl EventStore {
     fn conversions(&self) -> ConversionList {

--- a/optimizely/tests/decisions.rs
+++ b/optimizely/tests/decisions.rs
@@ -40,7 +40,7 @@ fn qa_rollout_flag() {
     assert_decision!(ctx, flag_key, "user15", true, "on");
 
     // Since this key is a rollout, no events should be dispatched
-    assert_eq!(ctx.decisions.borrow().len(), 0);
+    assert_eq!(ctx.decisions.len(), 0);
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn buy_button_flag() {
     assert_decision!(ctx, flag_key, "user31", true, "primary");
 
     // Each of those 32 users should dispatch an event
-    assert_eq!(ctx.decisions.borrow().len(), 32);
+    assert_eq!(ctx.decisions.len(), 32);
 }
 
 #[test]
@@ -98,5 +98,5 @@ fn invalid_flag() {
     assert_decision!(ctx, flag_key, "user4", false, "off");
 
     // Since this key does not exist, no events should be dispatched
-    assert_eq!(ctx.decisions.borrow().len(), 0);
+    assert_eq!(ctx.decisions.len(), 0);
 }

--- a/optimizely/tests/user_context.rs
+++ b/optimizely/tests/user_context.rs
@@ -51,5 +51,5 @@ fn user_context_track_event() {
     user_context.track_event("purchase");
 
     // Assert that exactly one event is dispatched
-    assert_eq!(ctx.conversions.borrow().len(), 1);
+    assert_eq!(ctx.conversions.len(), 1);
 }


### PR DESCRIPTION
When I was reusing the Client in the web application I was getting this error about thread safety and it would not compile.
```
error[E0277]: `(dyn EventDispatcher + 'static)` cannot be sent between threads safely
help: the trait `Sync` is not implemented for `(dyn EventDispatcher + 'static)`
help: the trait `Send` is not implemented for `(dyn EventDispatcher + 'static)`
```

Alternatively to adding the "Send" and "Sync" to the EventDispatcher trait, I could use this in my application to sync the threads, `Arc<Mutex<Client>>`. I am not sure of the benefits of one over the other, but in this SDK would optimise the readability of the application.

When updating the trait I had to update the tests module as that had a similar error about thread safety. Before changing the trait the test module had no problems. I could have used `Arc<Mutex<Client>>` on the tests, but this made it more verbose.